### PR TITLE
Add WIP MCP server for recipe-tool with execute and create functionalities

### DIFF
--- a/mcp-servers/recipe-tool/README.md
+++ b/mcp-servers/recipe-tool/README.md
@@ -1,0 +1,25 @@
+ # Recipe Tool MCP Server
+
+ This MCP server wraps the `recipe-tool` CLI and exposes its functionality as MCP tools.
+
+ ## Tools
+
+ - execute_recipe(recipe_path: str, context: dict[str, str] | None = None, log_dir: str = "logs") -> str  
+   Execute a recipe JSON file.
+
+ - create_recipe(idea_path: str, context: dict[str, str] | None = None, log_dir: str = "logs") -> str  
+   Create a recipe from an idea file.
+
+ ## Usage
+
+ Run as a standalone MCP server:
+
+ ```bash
+ recipe-tool-mcp-server
+ ```
+
+ Or install in Claude Desktop:
+
+ ```bash
+ mcp install recipe-tool-mcp-server
+ ```

--- a/mcp-servers/recipe-tool/pyproject.toml
+++ b/mcp-servers/recipe-tool/pyproject.toml
@@ -1,0 +1,19 @@
+ [project]
+ name = "recipe-tool-mcp-server"
+ version = "0.1.0"
+ description = "MCP server wrapping the recipe-tool CLI"
+ authors = [{ name = "MADE:Explorations Team" }]
+ license = "MIT"
+ readme = "README.md"
+ requires-python = ">=3.11"
+ dependencies = [
+     "mcp>=1.6.0",
+     "python-dotenv>=1.1.0",
+ ]
+
+ [project.scripts]
+ recipe-tool-mcp-server = "recipe_tool_mcp_server.cli:main"
+
+ [build-system]
+ requires = ["hatchling"]
+ build-backend = "hatchling.build"

--- a/mcp-servers/recipe-tool/recipe_tool_mcp_server/__init__.py
+++ b/mcp-servers/recipe-tool/recipe_tool_mcp_server/__init__.py
@@ -1,0 +1,4 @@
+"""
+Recipe Tool MCP Server package.
+"""
+__version__ = "0.1.0"

--- a/mcp-servers/recipe-tool/recipe_tool_mcp_server/cli.py
+++ b/mcp-servers/recipe-tool/recipe_tool_mcp_server/cli.py
@@ -1,0 +1,53 @@
+"""
+MCP server wrapping the recipe-tool CLI.
+Provides two tools: execute_recipe and create_recipe.
+"""
+from dotenv import load_dotenv
+from mcp.server.fastmcp import FastMCP
+
+# Import the CLI functions
+import recipe_tool
+from recipe_tool import execute_recipe as cli_execute, create_recipe as cli_create
+
+# Load environment variables from .env if present
+load_dotenv()
+
+# Initialize the MCP server
+mcp = FastMCP("Recipe Tool Server")
+
+@mcp.tool()
+async def execute_recipe(
+    recipe_path: str,
+    context: dict[str, str] | None = None,
+    log_dir: str = "logs"
+) -> str:
+    """
+    Execute a recipe JSON file.
+    """
+    # Convert context dict to CLI-style key=value strings
+    context_list = [f"{k}={v}" for k, v in (context or {}).items()]
+    # Call the underlying recipe-tool logic
+    await cli_execute(recipe_path, context_list, log_dir)
+    return f"Recipe executed successfully (logs in {log_dir})"
+
+@mcp.tool()
+async def create_recipe(
+    idea_path: str,
+    context: dict[str, str] | None = None,
+    log_dir: str = "logs"
+) -> str:
+    """
+    Create a recipe from an idea file.
+    """
+    context_list = [f"{k}={v}" for k, v in (context or {}).items()]
+    await cli_create(idea_path, context_list, log_dir)
+    return f"Recipe created successfully (logs in {log_dir})"
+
+def main() -> None:
+    """
+    Entry point for the MCP server.
+    """
+    mcp.run()
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,8 @@ python-code-tools = "python_code_tools.cli:main"
 package = true
 
 [tool.uv.sources]
-python-code-tools = { path = "mcp-servers/python-code-tools", editable = true }
+ python-code-tools = { path = "mcp-servers/python-code-tools", editable = true }
+ recipe-tool-mcp-server = { path = "mcp-servers/recipe-tool", editable = true }
 
 [tool.hatch.build.targets.wheel]
 packages = ["recipe_executor"]


### PR DESCRIPTION
Introduce an early, WIP MCP server that wraps the `recipe-tool` CLI, providing tools to execute and create recipes. This implementation includes necessary configurations and scripts for seamless integration.