### PR TITLE
Adds support for glob pattern in file reading

### DIFF
--- a/blueprints/recipe_executor/components/steps/read_files/read_files_docs.md
+++ b/blueprints/recipe_executor/components/steps/read_files/read_files_docs.md
@@ -77,6 +77,23 @@ You can read multiple files by providing a comma-separated string of paths:
   ]
 }
 ```
+You can also read multiple files by providing a glob pattern that will be expanded with the matching entities.
+A glob is a term used to define patterns for matching file and directory names based on wildcards. Globbing is the act of defining one or more glob patterns, and yielding files from either inclusive or exclusive matches :
+
+```json
+{
+  "steps": [
+    {
+      "type": "read_files",
+      "config": {
+        "path": "specs/*_spec.md",
+        "content_key": "component_specs",
+        "merge_mode": "concat"
+      }
+    }
+  ]
+}
+```
 
 You can also read multiple files by providing a list of path strings:
 

--- a/blueprints/recipe_executor/components/steps/read_files/read_files_spec.md
+++ b/blueprints/recipe_executor/components/steps/read_files/read_files_spec.md
@@ -23,6 +23,7 @@ The ReadFilesStep component reads one or more files from the filesystem and stor
 - Render template strings for the `path` parameter before evaluating the input type
 - Use template rendering to support dynamic paths for single path, comma-separated paths in one string, and lists of paths
 - Render template strings for the `content_key` parameter
+- Handle glob pattern in files
 - Handle missing files explicitly with meaningful error messages
 - Use consistent UTF-8 encoding for text files
 - Implement an `optional` flag to continue execution if files are missing


### PR DESCRIPTION
Enhances the file reading component to support glob patterns:
- Allows matching multiple file paths using wildcards
- Includes examples for glob pattern usage in documentation
- Improves flexibility in specifying input paths

This change facilitates more dynamic file selection, enhancing usability in environments with files following naming conventions.